### PR TITLE
Add optional option to unref request socket

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -446,6 +446,9 @@ Client.prototype.__execute = function(ctx, next) {
   var timeout = opts.hasOwnProperty('timeout') ?
     opts.timeout : self._opts.timeout;
 
+  var unref = opts.hasOwnProperty('unref') ?
+    opts.unref : self._opts.unref;
+
   self._log(['papi', 'request'].concat(opts.tags), ctx.req);
 
   var request = ctx.transport.request(ctx.req);
@@ -485,6 +488,13 @@ Client.prototype.__execute = function(ctx, next) {
     self._log(['papi', 'request', 'error', 'timeout'].concat(opts.tags));
     if (!err) err = errors.Timeout('request timed out (' + timeout + 'ms)');
     request.emit('error', err);
+  });
+
+  // unref the socket if requested
+  request.on('socket', function(socket) {
+    if (unref) {
+      socket.unref();
+    }
   });
 
   request.on('response', function(res) {


### PR DESCRIPTION
Without this option there is no way to ask the api to unref the socket.

This is important for long running requests for updates, but for which if the rest of the program is finished executing there is no reason to complete.