### PR TITLE
add request path to response logging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -528,6 +528,7 @@ Client.prototype.__execute = function(request, next) {
 
     self._log(['papi', 'response'].concat(opts.tags), {
       statusCode: res.statusCode,
+      path: req.path,
       headers: res.headers,
       remoteAddress: res.connection.remoteAddress,
       remotePort: res.connection.remotePort,

--- a/test/client.js
+++ b/test/client.js
@@ -1480,6 +1480,7 @@ describe('Client', function() {
                                 'method']);
         events[1][1].should.eql({
           statusCode: 200,
+          path: '/post',
           headers: {
             'content-type': 'application/json',
           },


### PR DESCRIPTION
In production we only log errors. Because the request properties are logged on request / at the INFO level we don't have context around errors.

If you think there's a better approach to doing this than adding path to all response logs please let me know.

Thanks!