### PR TITLE
set actualy req method/path on response

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -527,8 +527,8 @@ Client.prototype.__execute = function(request, next) {
     var bodyLength = 0;
 
     self._log(['papi', 'response'].concat(opts.tags), {
-      method: opts.method,
-      path: opts.path,
+      method: req.method,
+      path: req.path,
       statusCode: res.statusCode,
       headers: res.headers,
       remoteAddress: res.connection.remoteAddress,


### PR DESCRIPTION
using `opts.path` resulted in the raw path being logged rather than the actual request path.

```
"data": {
    "method": "GET",
    "path": "/library/shutterstock/{media_type}/model_releases",
    "statusCode": 200,
   ...
  },
```

rather than:

```
"data": {
    "method": "GET",
    "path": "/library/shutterstock/photo/model_releases?id=123",
    "statusCode": 200,
   ...
  },
```