### PR TITLE
expose error statusCode

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -578,6 +578,8 @@ Client.prototype.__execute = function(request, next) {
       if (Math.floor(res.statusCode / 100) !== 2) {
         var err = errors.Response();
 
+        err.statusCode = res.statusCode;
+
         if (res.body && mime === 'text/plain' && res.body.length < 80) {
           err.message = res.body;
         }


### PR DESCRIPTION
I was working on an err that came out as 
```javascript
{ [Error: not found]
  isPapi: true,
  isResponse: true,
  message: 'not found' }
```

Which wasn't detected as a `404` because it didn't have a `statusCode`. It would be nice for callers to have access to the original statusCode in the err, in case they want special logic per code.

@ndoyle @silas  Any objections to this :)
