### PR TITLE
Remove logging on res.connection as it does not exist in browser

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -542,9 +542,10 @@ Client.prototype.__execute = function(request, next) {
       method: opts.method,
       path: req.path,
       statusCode: res.statusCode,
-      headers: res.headers,
-      remoteAddress: res.connection.remoteAddress,
-      remotePort: res.connection.remotePort,
+      headers: res.headers
+// res.connection is null inside the browser
+//      remoteAddress: res.connection.remoteAddress,
+//      remotePort: res.connection.remotePort,
     });
 
     request.res = res;


### PR DESCRIPTION
I'm building a browser application that is basically a view on Consul, in the browser the res.connection object is not set (posssibly this is an XHR specific thing)

Seems like it's only used for logging and not really necessary anyway?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/silas/node-papi/12)
<!-- Reviewable:end -->
