### PR TITLE
Add fallback support to Buffer.from() for Node versions < 5.0.0

### DIFF
--- a/lib/codecs.js
+++ b/lib/codecs.js
@@ -16,6 +16,7 @@ var querystring = require('querystring');
 
 var text = {};
 
+const Buffer = require('safer-buffer').Buffer;
 text.encode = function(data) {
   return Buffer.from(data, 'utf8');
 };

--- a/lib/codecs.js
+++ b/lib/codecs.js
@@ -16,7 +16,7 @@ var querystring = require('querystring');
 
 var text = {};
 
-const Buffer = require('safer-buffer').Buffer;
+var Buffer = require('safer-buffer').Buffer;
 text.encode = function(data) {
   return Buffer.from(data, 'utf8');
 };

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "bugs": {
     "url": "https://github.com/silas/node-papi/issues"
   },
-  "homepage": "https://github.com/silas/node-papi"
+  "homepage": "https://github.com/silas/node-papi",
+  "dependencies": {
+    "safer-buffer": "^2.1.2"
+  }
 }


### PR DESCRIPTION
#Hello,

I am working on a project which need to use Node v4.5.5

As Buffer.from() is introduced in Node v5.10.0,
I am not able use **jenkins - https://github.com/silas/node-jenkins** for `jenkins.node.create` and `jenkins.node.disconnect()`, which are using **papi - https://github.com/silas/node-papi** as dependency.

So I have added support for lower Node versions using **safer-buffer - https://github.com/ChALkeR/safer-buffer**.

This PR is the solution for issue raised by me: https://github.com/silas/node-papi/issues/16