### PR TITLE
Check for connection before trying to log

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -537,14 +537,31 @@ Client.prototype.__execute = function(request, next) {
   req.on('response', function(res) {
     var chunks = [];
     var bodyLength = 0;
+    var remoteAddress, remotePort;
+
+    if (res.connection) {
+      if (res.connection.remoteAddress) {
+        remoteAddress = res.connection.remoteAddress;
+      } else {
+        remoteAddress = null;
+      }
+      if (res.connection.remotePort) {
+        remotePort = res.connection.remotePort;
+      } else {
+        remotePort = null;
+      }
+    } else {
+      remoteAddress = null;
+      remotePort = null;
+    }
 
     self._log(['papi', 'response'].concat(opts.tags), {
       method: opts.method,
       path: req.path,
       statusCode: res.statusCode,
       headers: res.headers,
-      remoteAddress: res.connection.remoteAddress,
-      remotePort: res.connection.remotePort,
+      remoteAddress: remoteAddress,
+      remotePort: remotePort,
     });
 
     request.res = res;

--- a/test/client.js
+++ b/test/client.js
@@ -1526,8 +1526,8 @@ describe('Client', function() {
           headers: {
             'content-type': 'application/json',
           },
-          remoteAddress: undefined,
-          remotePort: undefined,
+          remoteAddress: null,
+          remotePort: null,
         });
 
         done();


### PR DESCRIPTION
Hello,
I ran into an issue where the connection object on the response was undefined combined with your also-great node-jenkins module, throwing an error during logging even though the request could be successfully sent and received by the client, so here is a simple check to let the code proceed. Not sure if you can deduce a root-cause, but I can give more details if needed.